### PR TITLE
Fix Xcode build errors

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -10,20 +10,20 @@ public class WebviewConfiguratorPlugin: CAPPlugin {
     
     @objc func setBackForwardNavigationGestures(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            self.bridge.getWebView()?.allowsBackForwardNavigationGestures = call.getBool("enable") ?? false;
+            self.bridge?.webView?.allowsBackForwardNavigationGestures = call.getBool("enable") ?? false;
             call.resolve();
         }
     }
     
     @objc func getBackForwardNavigationGesturesState(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-                    call.resolve(["data":  self.bridge.getWebView()?.allowsBackForwardNavigationGestures ?? false]);
-               }
+            call.resolve(["data":  self.bridge?.webView?.allowsBackForwardNavigationGestures ?? false]);
+        }
     }
 
     @objc func setWebviewBounce(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            self.bridge.getWebView()?.scrollView.bounces = call.getBool("enable") ?? false;
+            self.bridge?.webView?.scrollView.bounces = call.getBool("enable") ?? false;
             call.resolve();
         }
     }


### PR DESCRIPTION
`Value of optional type 'CAPBridgeProtocol?' must be unwrapped to refer to member 'getWebView' of wrapped base type 'CAPBridgeProtocol'`

`'getWebView()' is deprecated: renamed to 'webView'`