### PR TITLE
Fix deprecated getWebView()-function

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -7,25 +7,25 @@ import Capacitor
  */
 @objc(WebviewConfiguratorPlugin)
 public class WebviewConfiguratorPlugin: CAPPlugin {
-    
+
     @objc func setBackForwardNavigationGestures(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            self.bridge.getWebView()?.allowsBackForwardNavigationGestures = call.getBool("enable") ?? false;
+            self.bridge?.webView?.allowsBackForwardNavigationGestures = call.getBool("enable") ?? false;
             call.resolve();
         }
     }
-    
+
     @objc func getBackForwardNavigationGesturesState(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-                    call.resolve(["data":  self.bridge.getWebView()?.allowsBackForwardNavigationGestures ?? false]);
+                    call.resolve(["data": self.bridge?.webView?.allowsBackForwardNavigationGestures ?? false]);
                }
     }
 
     @objc func setWebviewBounce(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            self.bridge.getWebView()?.scrollView.bounces = call.getBool("enable") ?? false;
+            self.bridge?.webView?.scrollView.bounces = call.getBool("enable") ?? false;
             call.resolve();
         }
     }
-    
+
 }


### PR DESCRIPTION
- `self.bridge` gives `Value of optional type 'CAPBridgeProtocol?' must be unwrapped to refer to member ...`-error
- `.getWebview()` is deprecated